### PR TITLE
feat: add user deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ https://supabase-crud-app-61cu.vercel.app/
 ### WANT
 * CRUD API
     * [ ] 更新API実装
-    * [ ] 削除API実装
+    * [x] 削除API実装
     * [ ] 詳細取得API実装
 * CRUD 画面
     * [ ] 登録画面実装
     * [ ] 更新画面実装
-    * [ ] 削除画面実装
+    * [x] 削除画面実装
     * [ ] 詳細画面実装
 * [ ] 認証機能実装

--- a/pages/api/users.ts
+++ b/pages/api/users.ts
@@ -42,6 +42,26 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     }
   }
 
-  res.setHeader('Allow', ['GET', 'POST'])
+  if (req.method === 'DELETE') {
+    console.log('[handler]DELETE')
+    const { id } = req.query
+    if (!id || Array.isArray(id)) {
+      return res.status(400).json({ error: 'Invalid user id' })
+    }
+    try {
+      const { error } = await supabase.from('users').delete().eq('id', id)
+      console.log('[handler]supabase delete response:', { error })
+      if (error) {
+        console.error('[handler]supabase delete error:', error)
+        return res.status(500).json({ error: error.message })
+      }
+      return res.status(200).json({ message: 'User deleted successfully' })
+    } catch (err) {
+      console.error('[handler]unexpected delete error:', err)
+      return res.status(500).json({ error: 'Internal server error' })
+    }
+  }
+
+  res.setHeader('Allow', ['GET', 'POST', 'DELETE'])
   res.status(405).end(`Method ${req.method} Not Allowed`)
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { User, Plus, Mail, UserIcon, RefreshCw } from 'lucide-react'
+import { User, Plus, Mail, UserIcon, RefreshCw, Trash2 } from 'lucide-react'
 
 interface UserData {
   id: number
@@ -74,6 +74,26 @@ export default function Home() {
       console.error('Error adding user:', err)
     } finally {
       setFormLoading(false)
+    }
+  }
+
+  // ユーザーを削除
+  const deleteUser = async (id: number) => {
+    if (!confirm('このユーザーを削除しますか？')) return
+    setError('')
+    setSuccess('')
+    try {
+      const response = await fetch(`/api/users?id=${id}`, { method: 'DELETE' })
+      if (!response.ok) {
+        const errorData = await response.json()
+        throw new Error(errorData.error || 'Failed to delete user')
+      }
+      setSuccess('ユーザーを削除しました')
+      fetchUsers()
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'ユーザーの削除に失敗しました'
+      setError(errorMessage)
+      console.error('Error deleting user:', err)
     }
   }
 
@@ -220,8 +240,15 @@ export default function Home() {
                           </p>
                         </div>
                       </div>
-                      <div className="text-xs text-gray-400">
-                        ID: {user.id}
+                      <div className="flex items-center gap-2 text-xs text-gray-400">
+                        <span>ID: {user.id}</span>
+                        <button
+                          onClick={() => deleteUser(user.id)}
+                          className="p-1 text-red-500 hover:bg-red-50 rounded"
+                          title="削除"
+                        >
+                          <Trash2 className="w-4 h-4" />
+                        </button>
                       </div>
                     </div>
                     {user.created_at && (
@@ -252,7 +279,7 @@ export default function Home() {
                 <Plus className="w-5 h-5 text-green-600" />
                 <span className="text-sm font-medium text-green-600">API</span>
               </div>
-              <p className="text-lg font-semibold text-green-900 mt-1">GET / POST</p>
+              <p className="text-lg font-semibold text-green-900 mt-1">GET / POST / DELETE</p>
             </div>
             <div className="bg-purple-50 p-4 rounded-lg">
               <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- support deleting users via DELETE /api/users
- allow removing users from the UI and update stats

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b1315e34f88321b107669a650a215c